### PR TITLE
Legg til checkout-tag action

### DIFF
--- a/actions/checkout-tag/Dockerfile
+++ b/actions/checkout-tag/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine/git
+RUN apk add jq
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/checkout-tag/README.md
+++ b/actions/checkout-tag/README.md
@@ -1,0 +1,92 @@
+# checkout-tag
+
+Check out a specific git tag, and optionally assert that the tag is on origin/master
+
+## Usage
+
+### nais/deploy action
+
+Deploy to prod-sbs:
+
+```yaml
+  deploy_prod:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'deploy_prod_tag'
+    steps:
+    - uses: navikt/sosialhjelp-ci/actions/checkout-tag@master
+      with:
+        tag: ${{ github.event.client_payload.TAG }}
+        vars: "nais/prod/default.json"
+        assert_master: "true"
+    - uses: nais/deploy/actions/deploy@v1
+      env:
+        APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+        CLUSTER: prod-sbs
+        RESOURCE: "nais.yaml"
+        VARS: "nais/prod/default.json"
+```
+
+Deploy to dev-sbs:
+
+```yaml
+  deploy_miljo:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'deploy_miljo_tag'
+    steps:
+    - uses: navikt/sosialhjelp-ci/actions/checkout-tag@master
+      with:
+        tag: ${{ github.event.client_payload.TAG }}
+        vars: "nais/dev/${{ github.event.client_payload.MILJO }}.json"
+    - uses: nais/deploy/actions/deploy@v1
+      env:
+        APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+        CLUSTER: prod-sbs
+        RESOURCE: "nais.yaml"
+        VARS: "nais/dev/${{ github.event.client_payload.MILJO }}.json"
+```
+
+### deployment-cli Docker container
+
+Deploy to prod-sbs:
+
+```yaml
+  deploy_prod:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'deploy_prod_tag'
+    container: navikt/deployment-cli:0.4.0
+    steps:
+    - uses: navikt/sosialhjelp-ci/actions/checkout-tag@master
+      with:
+        tag: ${{ github.event.client_payload.TAG }}
+        assert_master: "true"
+    - run: |
+        deployment-cli deploy create \
+          --cluster=prod-sbs --repository=${GITHUB_REPOSITORY} --team=digisos \
+          -r=nais.yaml --var version=${VERSION} --vars=nais/prod/default.json
+      env:
+        VERSION: ${{ github.event.client_payload.TAG }}
+        DEPLOYMENT_USERNAME: ${{ secrets.DEPLOYMENT_USERNAME }}
+        DEPLOYMENT_PASSWORD: ${{ secrets.DEPLOYMENT_PASSWORD }}
+```
+
+Deploy to dev-sbs:
+
+```yaml
+  deploy_miljo:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'deploy_miljo_tag'
+    container: navikt/deployment-cli:0.4.0
+    steps:
+    - uses: navikt/sosialhjelp-ci/actions/checkout-tag@master
+      with:
+        tag: ${{ github.event.client_payload.TAG }}
+    - run: |
+        deployment-cli deploy create \
+          --cluster=dev-sbs --repository=${GITHUB_REPOSITORY} --team=digisos \
+          -r=nais.yaml --var version=${VERSION} --vars=nais/dev/${MILJO}.json
+      env:
+        VERSION: ${{ github.event.client_payload.TAG }}
+        MILJO: ${{ github.event.client_payload.MILJO }}
+        DEPLOYMENT_USERNAME: ${{ secrets.DEPLOYMENT_USERNAME }}
+        DEPLOYMENT_PASSWORD: ${{ secrets.DEPLOYMENT_PASSWORD }}
+```

--- a/actions/checkout-tag/action.yml
+++ b/actions/checkout-tag/action.yml
@@ -1,0 +1,16 @@
+name: "create-artifact-version"
+description: "Check out a specific git tag, and optionally assert that the tag is on origin/master"
+inputs:
+  tag:
+    description: "The git tag to check out"
+    required: true
+  assert_master:
+    description: "Check if tag is merged with origin/master"
+    required: false
+    default: "false"
+  vars:
+    description: "A json file with template variables to add \".version = $tag\" to"
+    required: false
+runs:
+  using: "docker"
+  image: "Dockerfile"

--- a/actions/checkout-tag/entrypoint.sh
+++ b/actions/checkout-tag/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+if [ "${INPUT_ASSERT_MASTER}" = "true" ]; then
+  git clone -qb "${INPUT_TAG}" "https://github.com/${GITHUB_REPOSITORY}" "${GITHUB_WORKSPACE}"
+  if [ "$(git merge-base origin/master HEAD)" != "$(git rev-parse HEAD)" ]; then
+    echo "${INPUT_TAG} has not been merged into master" 1>&2
+    exit 1
+  fi
+else
+  # If no assert_master, only single branch is needed
+  git clone -qb "${INPUT_TAG}" --single-branch "https://github.com/${GITHUB_REPOSITORY}" "${GITHUB_WORKSPACE}"
+fi
+
+# Add .version to json file if "input_vars" is set
+if [ -f "${INPUT_VARS}" ]; then
+  TEMP_FILE="/tmp/input_vars.json"
+  jq ".version = \"${INPUT_TAG}\"" "${INPUT_VARS}" > ${TEMP_FILE}
+  if [ -s ${TEMP_FILE} ]; then
+    mv ${TEMP_FILE} "${INPUT_VARS}"
+  fi
+fi


### PR DESCRIPTION
- Kloner repo til spesifikk tag/branch
- Assert at tag/branch er fletta i master (valgfri)
- Legg til .version i vars json fil for bruk i nais/deploy (valgfri)

Brukes som beskrevet i README, og er ment å erstatte duplisert logikk i deploy-jobber. Actionen er testet grundig på privat repo, men nais/deploy- og deployment-cli-eksemplene i README er utestet.

Bruker `jq` i stedet for `yq` siden den finnes i alpine-repoet, og siden alle miljø-configene uansett er json.